### PR TITLE
updated packages and bug fix

### DIFF
--- a/AuthHost/AuthHost.csproj
+++ b/AuthHost/AuthHost.csproj
@@ -34,13 +34,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Nancy">
-      <HintPath>..\packages\Nancy.0.23.0\lib\net40\Nancy.dll</HintPath>
+      <HintPath>..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
     </Reference>
     <Reference Include="Nancy.Hosting.Self">
-      <HintPath>..\packages\Nancy.Hosting.Self.0.23.0\lib\net40\Nancy.Hosting.Self.dll</HintPath>
+      <HintPath>..\packages\Nancy.Hosting.Self.0.23.2\lib\net40\Nancy.Hosting.Self.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PusherServer">
       <HintPath>..\packages\PusherServer.2.0.0-beta-4\lib\net35\PusherServer.dll</HintPath>

--- a/AuthHost/packages.config
+++ b/AuthHost/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Nancy" version="0.23.0" targetFramework="net40" />
-  <package id="Nancy.Hosting.Self" version="0.23.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
+  <package id="Nancy" version="0.23.2" targetFramework="net40" />
+  <package id="Nancy.Hosting.Self" version="0.23.2" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40" />
   <package id="PusherServer" version="2.0.0-beta-4" targetFramework="net40" />
   <package id="RestSharp" version="104.4.0" targetFramework="net40" />
 </packages>

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -42,7 +42,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WebSocket4Net">
-      <HintPath>..\packages\WebSocket4Net.0.9\lib\net40\WebSocket4Net.dll</HintPath>
+      <HintPath>..\packages\WebSocket4Net.0.10\lib\net40\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ExampleApplication/packages.config
+++ b/ExampleApplication/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WebSocket4Net" version="0.9" targetFramework="net40" />
+  <package id="WebSocket4Net" version="0.10" targetFramework="net40" />
 </packages>

--- a/PusherClient/PusherClient.csproj
+++ b/PusherClient/PusherClient.csproj
@@ -34,14 +34,14 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data" />
     <Reference Include="WebSocket4Net">
-      <HintPath>..\packages\WebSocket4Net.0.9\lib\net40\WebSocket4Net.dll</HintPath>
+      <HintPath>..\packages\WebSocket4Net.0.10\lib\net40\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/PusherClient/packages.config
+++ b/PusherClient/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
-  <package id="WebSocket4Net" version="0.9" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40" />
+  <package id="WebSocket4Net" version="0.10" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Updated the nuget packages to get the latest versions.  There was a bug fix in the web sockets library that made the connection more stable.  The bug fix was when pusher was returning an "pusher:error" event back.  The data object was expected to be a string and when this event comes through it isn't, it's an object.  I utilized the JSON.NET library to work around this and stop the exception from being thrown.
