### PR TITLE
Remove extra call to `ChangeState` in `websocket_Closed`

### DIFF
--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -226,7 +226,6 @@ namespace PusherClient
                 ChangeState(ConnectionState.WaitingToReconnect);
                 Thread.Sleep(_backOffMillis);
                 _backOffMillis = Math.Min(MAX_BACKOFF_MILLIS, _backOffMillis + BACK_OFF_MILLIS_INCREMENT);
-                ChangeState(ConnectionState.Connecting);
                 Connect();
             }
         }


### PR DESCRIPTION
`ChangeState` is already called in `Connect`. At the moment `Connection state: Connecting` is logged twice -- confusing.