### PR TITLE
Prevent multiple connects

### DIFF
--- a/PusherClient/ConnectionState.cs
+++ b/PusherClient/ConnectionState.cs
@@ -6,7 +6,6 @@
         Connecting,
         Connected,
         Unavailable,
-        Failed,
         Disconnected,
         WaitingToReconnect
     }

--- a/PusherClient/ConnectionState.cs
+++ b/PusherClient/ConnectionState.cs
@@ -5,7 +5,6 @@
         Initialized,
         Connecting,
         Connected,
-        Unavailable,
         Disconnected,
         WaitingToReconnect
     }

--- a/PusherClient/ErrorCodes.cs
+++ b/PusherClient/ErrorCodes.cs
@@ -14,7 +14,6 @@
         ClientOverRateLimit = 4301,
 
         // Library codes
-        ConnectionFailed = 5000, 
         ChannelAuthorizerNotSet = 5001,
         NotConnected = 5002,
         SubscriptionError = 5003

--- a/PusherClient/Pusher.cs
+++ b/PusherClient/Pusher.cs
@@ -113,10 +113,6 @@ namespace PusherClient
                     case ConnectionState.Connecting:
                         Trace.TraceEvent(TraceEventType.Warning, 0, "Attempt to connect when connection is already in 'Connecting' state. New attempt has been ignored.");
                         break;
-                    case ConnectionState.Failed:
-                        Trace.TraceEvent(TraceEventType.Error, 0, "Cannot attempt re-connection once in 'Failed' state");
-                        RaiseError(new PusherException("Cannot attempt re-connection once in 'Failed' state", ErrorCodes.ConnectionFailed));
-                        break;
                 }
             }
 
@@ -127,7 +123,7 @@ namespace PusherClient
 
             // TODO: Fallback to secure?
 
-            string url = String.Format("{0}{1}/app/{2}?protocol={3}&client={4}&version={5}", 
+            string url = String.Format("{0}{1}/app/{2}?protocol={3}&client={4}&version={5}",
                 scheme, _options.Host, _applicationKey, Settings.Default.ProtocolVersion, Settings.Default.ClientName,
                 Settings.Default.VersionNumber);
 
@@ -143,7 +139,7 @@ namespace PusherClient
                 }
             }
             _connection.Connect();
-            
+
         }
 
         public void Disconnect()

--- a/PusherClient/Pusher.cs
+++ b/PusherClient/Pusher.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace PusherClient
 {
@@ -100,20 +101,14 @@ namespace PusherClient
 
         #region Public Methods
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Connect()
         {
             // Check current connection state
             if (_connection != null)
             {
-                switch (_connection.State)
-                {
-                    case ConnectionState.Connected:
-                        Trace.TraceEvent(TraceEventType.Warning, 0, "Attempt to connect when connection is already in 'Connected' state. New attempt has been ignored.");
-                        break;
-                    case ConnectionState.Connecting:
-                        Trace.TraceEvent(TraceEventType.Warning, 0, "Attempt to connect when connection is already in 'Connecting' state. New attempt has been ignored.");
-                        break;
-                }
+              Trace.TraceEvent(TraceEventType.Warning, 0, "Attempt to connect when another connection has already started. New attempt has been ignored.");
+              return;
             }
 
             var scheme = "ws://";


### PR DESCRIPTION
Synchronized Connect() method ensures connections cannot be opened concurrently. Once a Connection object has been instantiated, subsequent calls to connect are ignored.

This is essentially the approach the JS client has (although it does not need to worry about concurrent Connects): https://github.com/pusher/pusher-js/blob/master/src/core/connection/connection_manager.ts#L95-L97