### PR TITLE
Bugfix/connection memory leak

### DIFF
--- a/PusherClient/Connection.cs
+++ b/PusherClient/Connection.cs
@@ -75,7 +75,13 @@ namespace PusherClient
         internal void Disconnect()
         {
             _allowReconnect = false;
+
+            _websocket.Opened -= websocket_Opened;
+            _websocket.Error -= websocket_Error;
+            _websocket.Closed -= websocket_Closed;
+            _websocket.MessageReceived -= websocket_MessageReceived;
             _websocket.Close();
+
             ChangeState(ConnectionState.Disconnected);
         }
 

--- a/PusherClient/Pusher.cs
+++ b/PusherClient/Pusher.cs
@@ -126,23 +126,49 @@ namespace PusherClient
                     Settings.Default.VersionNumber);
 
                 _connection = new Connection(this, url);
-                _connection.Connected += _connection_Connected;
-                _connection.ConnectionStateChanged +=_connection_ConnectionStateChanged;
-                if (_errorEvent != null)
-                {
-                    // subscribe to the connection's error handler
-                    foreach (ErrorEventHandler handler in _errorEvent.GetInvocationList())
-                    {
-                        _connection.Error += handler;
-                    }
-                }
+                RegisterEventsOnConnection();
                 _connection.Connect();
+            }
+        }
+
+        private void RegisterEventsOnConnection()
+        {
+            _connection.Connected += _connection_Connected;
+            _connection.ConnectionStateChanged += _connection_ConnectionStateChanged;
+            if (_errorEvent != null)
+            {
+                // subscribe to the connection's error handler
+                foreach (ErrorEventHandler handler in _errorEvent.GetInvocationList())
+                {
+                    _connection.Error += handler;
+                }
             }
         }
 
         public void Disconnect()
         {
+            UnregisterEventsOnDisconnection();
+            MarkChannelsAsUnsubscribed();
             _connection.Disconnect();
+            _connection = null;
+        }
+
+        private void UnregisterEventsOnDisconnection()
+        {
+            if (_connection != null)
+            {
+                _connection.Connected -= _connection_Connected;
+                _connection.ConnectionStateChanged -= _connection_ConnectionStateChanged;
+
+                if (_errorEvent != null)
+                {
+                    // unsubscribe to the connection's error handler
+                    foreach (ErrorEventHandler handler in _errorEvent.GetInvocationList())
+                    {
+                        _connection.Error -= handler;
+                    }
+                }
+            }
         }
 
         public Channel Subscribe(string channelName)


### PR DESCRIPTION
Rebased: https://github.com/pusher-community/pusher-websocket-dotnet/pull/27

I no longer think it's necessary to call `_connection.Disconnect();` because `_connection` will never be not null, and the only way it can be null is if `Disconnect()` has been explicitly called.

Also no longer call `UnregisterEventsOnConnection();` in `Connect()`, again because in order to make it that far into the function, `Disconnect()` must have already been called (which already calls this).